### PR TITLE
fix: 严格遵守 Gemini API 请求格式规范 (适配 NewAPI 等中转)

### DIFF
--- a/client/CustomGoogleGeminiClient.js
+++ b/client/CustomGoogleGeminiClient.js
@@ -294,11 +294,10 @@ export class CustomGoogleGeminiClient extends GoogleGeminiClient {
     }
     if (systemMessage) {
       body.system_instruction = {
-        parts: {
-          text: systemMessage
-        }
+        parts: [{ text: systemMessage }] 
       }
     }
+
     if (this.tools?.length > 0) {
       body.tools.push({
         function_declarations: this.tools.map(tool => tool.function())
@@ -344,6 +343,7 @@ export class CustomGoogleGeminiClient extends GoogleGeminiClient {
       method: 'POST',
       body: JSON.stringify(body),
       headers: {
+        'Content-Type': 'application/json',
         'x-goog-api-key': this._key
       }
     })


### PR DESCRIPTION
### 问题现象
在使用中转站时，如newapi无法正常回复gemini格式内容，发现其请求格式有要求，于是进行修改

### 修改内容
1. 在 `newFetch` 的 headers 中补充了 `'Content-Type': 'application/json'`。
2. 将 `system_instruction.parts` 的赋值结构修正为标准的数组格式 `[{ text: systemMessage }]`。

本人已经测试，可以正常回复